### PR TITLE
Align product card content vertically

### DIFF
--- a/src/transform.mjs
+++ b/src/transform.mjs
@@ -53,15 +53,15 @@ function productCardHTML(p, perRow) {
     <!--[if !mso]><!-->
     <td class="product-cell" style="vertical-align:top; width:${widthPercent}%; padding:10px;">
     <!--<![endif]-->
-      <a href="${p.link}" style="text-decoration:none; color:#000; display:block;">
-        <div style="width:100%; text-align:center;">
+      <a href="${p.link}" style="text-decoration:none; color:#000; display:flex; flex-direction:column; align-items:center; text-align:center; gap:8px;">
+        <div style="width:100%; display:flex; justify-content:center;">
           <img src="${p.image}" alt="${esc(p.title)}"
-               style="width:100%; max-width:180px; height:180px; object-fit:contain; display:inline-block; margin-bottom:8px;" />
+               style="width:100%; max-width:180px; height:180px; object-fit:contain; display:block;" />
         </div>
-        <div style="margin:0; font-weight:bold; font-size:14px; line-height:1.3; text-align:left; min-height:40px;">
+        <div style="margin:0; font-weight:bold; font-size:14px; line-height:1.3; text-align:center; min-height:40px; width:100%;">
           ${esc(p.title)}
         </div>
-        <div style="margin-top:4px; color:#e60000; font-weight:bold; text-align:left; font-size:16px;">
+        <div style="margin-top:0; color:#e60000; font-weight:bold; text-align:center; font-size:16px; width:100%;">
           € ${isFinite(p.price) ? p.price.toFixed(2) : esc(p.price)}
         </div>
       </a>


### PR DESCRIPTION
## Summary
- adjust the product card markup so the image, title, and price are stacked vertically inside each block
- center the card contents to keep the vertically stacked layout consistent

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d63770e65483328ce70aac8a59de57